### PR TITLE
Method now checks the `$fillable` property of the entity/Model

### DIFF
--- a/src/Prjkt/Component/Repofuck/Repofuck.php
+++ b/src/Prjkt/Component/Repofuck/Repofuck.php
@@ -307,13 +307,17 @@ abstract class Repofuck
 			throw new EntityNotDefined;
 		}
 
+		$fillable = $entity->getFillable();
+		
 		foreach($inserts as $key => $val)
 		{
 			if ( count($keys) > 0 && ! in_array($keys, $key) ) {
 				break;
 			}
 
-			$entity->{$key} = $val;
+			if (array_key_exists($key, $fillable)){
+				$entity->{$key} = $val;
+			}
 		}
 
 		return $entity;

--- a/src/Prjkt/Component/Repofuck/Repofuck.php
+++ b/src/Prjkt/Component/Repofuck/Repofuck.php
@@ -306,8 +306,6 @@ abstract class Repofuck
 		if ( ! $this->entity instanceof Model ) {
 			throw new EntityNotDefined;
 		}
-
-		$fillable = $entity->getFillable();
 		
 		foreach($inserts as $key => $val)
 		{

--- a/src/Prjkt/Component/Repofuck/Repofuck.php
+++ b/src/Prjkt/Component/Repofuck/Repofuck.php
@@ -311,13 +311,11 @@ abstract class Repofuck
 		
 		foreach($inserts as $key => $val)
 		{
-			if ( count($keys) > 0 && ! in_array($keys, $key) ) {
+			if ( count($keys) > 0 && ! in_array($key, $keys) ) {
 				break;
 			}
 
-			if (array_key_exists($key, $fillable)){
 				$entity->{$key} = $val;
-			}
 		}
 
 		return $entity;


### PR DESCRIPTION
This is the fix for Issue #25.

NOTE: The user is forced to supply/define the elements of the `$fillable` property of a `Model` object to be used as the `$entity` in `map()` method.
