### PR TITLE
Persistent 'key' and 'data' manipulation

### DIFF
--- a/src/Prjkt/Component/Repofuck/Exceptions/InvalidCallback.php
+++ b/src/Prjkt/Component/Repofuck/Exceptions/InvalidCallback.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Prjkt\Component\Repofuck\Exceptions;
+
+class InvalidCallback extends \Exception {}

--- a/src/Prjkt/Component/Repofuck/Exceptions/InvalidCallbackReturn.php
+++ b/src/Prjkt/Component/Repofuck/Exceptions/InvalidCallbackReturn.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Prjkt\Component\Repofuck\Exceptions;
+
+class InvalidCallbackReturn extends \Exception {}

--- a/src/Prjkt/Component/Repofuck/Repofuck.php
+++ b/src/Prjkt/Component/Repofuck/Repofuck.php
@@ -204,7 +204,7 @@ abstract class Repofuck
 	 *
 	 * @return array
 	 */
-	public function getData() : array
+	public function getKeys() : array
 	{
 		return $this->keys;
 	}


### PR DESCRIPTION
- added new functions
  - 'getKeys'
  - 'getData'
  - 'setKeys'
  - 'setData'
- parameters for 'create' and 'update' are deferred to 'prepare'
- added sanity checks for 'prepare' introducing two exceptions
  - 'InvalidCallback'
  - 'InvalidCallbackReturn'
