### PR TITLE
Transforming Repofuck as a Container

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,18 @@ Repofuck is dynamically persistent repository provider that also acts as a facto
 
 ### Sample Usage
 ```php
-$data = $repo->prepare(['foor' => 'bar'], function ($params, $repo)
+$data = $repo->prepare(['foor' => 'bar'], function ($r, $q)
 {
 	//.. operations here
-	return $repo->entity
+	return $r->entity
 		->with('relationship')
-		->where($params);
+		->where($q['where']);
 	
-})->get();
+}, [
+	'where' => [
+		['foo', 'LIKE', '%BAR%']
+	]
+])->get();
 ```
 As you can see above. We are fetching data with the parameters with a relationship. The repository will be persisting the return of the callback and we can perform another operation. In which case we are performing a get.
 

--- a/src/Prjkt/Component/Repofuck/Containers/Entities.php
+++ b/src/Prjkt/Component/Repofuck/Containers/Entities.php
@@ -7,10 +7,15 @@ use Illuminate\Database\Eloquent\{
 	Builder
 };
 
-use Prjkt\Component\Repofuck\Exceptions\ResourceNotFound;
+use Prjkt\Component\Repofuck\{
+	Exceptions\ResourceNotFound,
+	Traits\Operations
+};
 
 class Entities
 {
+	use Operations;
+	
 	/**
 	 * Entity pointer
 	 *
@@ -33,6 +38,22 @@ class Entities
 	public function current()
 	{
 		return $this->entity;
+	}
+
+	/**
+	 * Checks the entities container if an entity exists
+	 * ~ defer to first configured if none provided
+	 *
+	 * @param string $entity
+	 * @return bool
+	 */
+	public function has(string $entity = null) : bool
+	{
+		if ( is_null($entity) ) {
+			return $this->isEloquent($this->entity) ? true : false;
+		}
+
+		return array_key_exists($entity, $this->entities) ? true : false;
 	}
 
 	/**

--- a/src/Prjkt/Component/Repofuck/Containers/Entities.php
+++ b/src/Prjkt/Component/Repofuck/Containers/Entities.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Prjkt\Component\Repofuck\Repofuck\Containers;
+
+use Illuminate\Database\Eloquent\{
+	Model,
+	Builder
+};
+
+use Prjkt\Component\Repofuck\Exceptions\ResourceNotFound;
+
+class Entities
+{
+	/**
+	 * Entity pointer
+	 *
+	 * @var \Illuminate\Database\Eloquent\Model
+	 */
+	protected $entity;
+
+	/**
+	 * Entities array container
+	 *
+	 * @var array
+	 */
+	protected $entities = [];
+
+	/**
+	 * Get the current entity pointer
+	 *
+	 * @param \Illuminate\Database\Eloquent\Model
+	 */
+	public function current()
+	{
+		return $this->entity;
+	}
+
+	/**
+	 * Adds the entity to the container
+	 *
+	 * @param \Illuminate\Database\Eloquent\Model
+	 * @return \Prjkt\Component\Repofuck\Containers\Entities
+	 */
+	public function push(Model $entity)
+	{
+		$this->entities[$entity->getTable()] = $entity;
+
+		return $this;
+	}
+
+	/**
+	 * Resolves the entity given by its table name or the first one configured
+	 *
+	 * @param string $entity
+	 * @throws \Prjkt\Component\Repofuck\Exceptions\EntityNotDefined
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function resolve(string $entity = null) : Model
+	{
+		switch($entities)
+		{
+			case ($this->hasValues($this->entities) && $entity === null):
+				return array_key_exists($parsedName, $this->entities) ?
+					$this->entities[$this->resolveRepoName()] : array_values($this->entities)[0];
+			break;
+
+			case array_key_exists($entity, $this->entities):
+				return $this->entities[$entity];
+			break;
+		}
+
+		throw new Exceptions\EntityNotDefined;
+	}
+
+	/**
+	 * Sets the current entity
+	 *
+	 * @param mixed $entity
+	 * @return \Prjkt\Component\Repofuck\Containers\Entities
+	 */
+	public function set($entity) : \Prjkt\Component\Repofuck\Containers\Entities
+	{
+		switch($entity)
+		{
+			case $entity instanceof Model || $entity instanceof Builder:
+
+				$this->entity = $entity;
+
+			break;
+				
+			case is_string($entity):
+
+				$this->entity = $this->resolve($entity);
+
+			break;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Mimics the original behavior of the DI
+	 *
+	 * @return Object
+	 */
+	public function __get($key)
+	{
+		return $this->resolve($key);
+	}
+}

--- a/src/Prjkt/Component/Repofuck/Containers/Repositories.php
+++ b/src/Prjkt/Component/Repofuck/Containers/Repositories.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Prjkt\Component\Repofuck\Containers\Repositories;
+
+
+use Prjkt\Component\Repofuck\{
+	Exceptions\ResourceNotDefined,
+	Traits\Operations
+};
+
+class Repositories
+{
+	use Operations;
+
+	/**
+	 * Repository pointer
+	 *
+	 * @var \Prjkt\Component\Repofuck\Repofuck
+	 */
+	protected $repository;
+
+	/**
+	 * Repositories array container
+	 *
+	 * @var array
+	 */
+	protected $repositories = [];
+
+	/**
+	 * Returns the persisted repository
+	 *
+	 * @return \Prjkt\Component\Repofuck\Repofuck
+	 */
+	public function current() : \Prjkt\Component\Repofuck\Repofuck
+	{
+		return $this->repository;
+	}
+
+	/**
+	 * Pushes the repository to the container
+	 *
+	 * @param \Prjkt\Component\Repofuck\Repofuck $repository
+	 * @return \Prjkt\Component\Repofuck\Containers\Repositories
+	 */
+	public function push(\Prjkt\Component\Repofuck\Repofuck $repository) : \Prjkt\Component\Repofuck\Containers\Repositories
+	{
+		$this->repositories[$this->resolveRepoName($repository)] = $repository;
+
+		return $this;
+	}
+
+	/**
+	 * Resolves the entity given by its name
+	 *
+	 * @param string $repository
+	 * @throws \Prjkt\Component\Repofuck\Exceptions\RepositoryNotDefined
+	 * @return \Prjkt\Component\Repofuck\Repofuck
+	 */
+	public function resolve(string $repository) : \Prjkt\Component\Repofuck\Repofuck
+	{
+		if ( ! array_key_exists($repository, $this->repositories) ) {
+			throw new RepositoryNotDefined;
+		}
+
+		return $this->repositories[$repository];
+	}
+
+	/**
+	 * Sets a repository pointer
+	 *
+	 * @param \Prjkt\Component\Repofuck\Repofuck $repository
+	 * @return \Prjkt\Component\Repofuck\Repofuck
+	 */
+	protected function set(\Prjkt\Component\Repofuck\Repofuck $repository) : \Prjkt\Component\Repofuck\Containers\Repositories
+	{
+		$this->repository = $repository;
+
+		return $this;
+	}
+
+	/**
+	 * Mimics the original behavior of the DI
+	 *
+	 * @return Object
+	 */
+	public function __get($key)
+	{
+		return $this->resolve($key);
+	}
+}

--- a/src/Prjkt/Component/Repofuck/Containers/Repositories.php
+++ b/src/Prjkt/Component/Repofuck/Containers/Repositories.php
@@ -37,6 +37,22 @@ class Repositories
 	}
 
 	/**
+	 * Checks the repositories container if a repository exists
+	 * ~ defer to first configured if none provided
+	 *
+	 * @param string $repository
+	 * @return bool
+	 */
+	public function has(string $repository = null) : bool
+	{
+		if ( is_null($repository) ) {
+			return $this->isRepofuck($this->repository) ? true : false;
+		}
+
+		return array_key_exists($repository, $this->repositories) ? true : false;
+	}
+
+	/**
 	 * Pushes the repository to the container
 	 *
 	 * @param \Prjkt\Component\Repofuck\Repofuck $repository

--- a/src/Prjkt/Component/Repofuck/Exceptions/RepositoryNotDefined.php
+++ b/src/Prjkt/Component/Repofuck/Exceptions/RepositoryNotDefined.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Prjkt\Component\Repofuck\Exceptions;
+
+class RepositoryNotDefined extends \Exception {}

--- a/src/Prjkt/Component/Repofuck/Traits/Operations.php
+++ b/src/Prjkt/Component/Repofuck/Traits/Operations.php
@@ -16,6 +16,17 @@ trait Operations
 	}
 
 	/**
+	 * Checks if the value given is an instance of Eloquent
+	 *
+	 * @param mixed
+	 * @return bool
+	 */
+	public function isEloquent($value) : bool
+	{
+		return is_object($value) && $value instanceof \Illuminate\Database\Eloquent\Model ? true : false;
+	}
+
+	/**
 	 * Checks if the value given is an instance of Repofuck
 	 *
 	 * @param mixed

--- a/src/Prjkt/Component/Repofuck/Traits/Operations.php
+++ b/src/Prjkt/Component/Repofuck/Traits/Operations.php
@@ -14,4 +14,25 @@ trait Operations
 	{
 		return count($array) > 0 ? true : false;
 	}
+
+	/**
+	 * Checks if the value given is an instance of Repofuck
+	 *
+	 * @param mixed
+	 * @return bool
+	 */
+	public function isRepofuck($value) : bool
+	{
+		return is_object($value) && $value instanceof \Prjkt\Component\Repofuck\Repofuck ? true : false;
+	}
+
+	/**
+	 * Resolves the name of the repository
+	 *
+	 * @return string
+	 */
+	public function resolveRepoName(\Prjkt\Component\Repofuck\Repofuck $repository) : string
+	{
+		return strtolower(str_replace('Repository', '', (new \ReflectionClass($repository))->getShortName()));
+	}
 }


### PR DESCRIPTION
- Improvements
  - Updated README
  - Loading of resources will now resolve to proper containers
  - Added containers `Entities` & `Repositories` for easy access and manipulation in closures
  - Added `isRepofuck`, `isEloquent` functions to `Operations` trait for ease of use
- Bug Fixes
  - Using `update` will update the current _configured_ entity instead of the intended one
