### PR TITLE
Minor error: Misplaced operands

### DIFF
--- a/src/Prjkt/Component/Repofuck/Containers/Entities.php
+++ b/src/Prjkt/Component/Repofuck/Containers/Entities.php
@@ -73,16 +73,17 @@ class Entities
 	 * Resolves the entity given by its table name or the first one configured
 	 *
 	 * @param string $entity
+	 * @param \Prjkt\Component\Repofuck\Repofuck
 	 * @throws \Prjkt\Component\Repofuck\Exceptions\EntityNotDefined
 	 * @return \Illuminate\Database\Eloquent\Model
 	 */
-	public function resolve(string $entity = null) : Model
+	public function resolve(string $entity = null, string $repoName = null) : Model
 	{
-		switch($entities)
+		switch($entity)
 		{
-			case ($this->hasValues($this->entities) && $entity === null):
-				return array_key_exists($parsedName, $this->entities) ?
-					$this->entities[$this->resolveRepoName()] : array_values($this->entities)[0];
+			case null && $this->hasValues($this->entities):
+				return array_key_exists($repoName, $this->entities) ?
+					$this->entities[$repoName] : array_values($this->entities)[0];
 			break;
 
 			case array_key_exists($entity, $this->entities):

--- a/src/Prjkt/Component/Repofuck/Containers/Entities.php
+++ b/src/Prjkt/Component/Repofuck/Containers/Entities.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Prjkt\Component\Repofuck\Repofuck\Containers;
+namespace Prjkt\Component\Repofuck\Containers;
 
 use Illuminate\Database\Eloquent\{
 	Model,
@@ -14,7 +14,7 @@ use Prjkt\Component\Repofuck\{
 
 class Entities
 {
-	use Operations;
+	use \Prjkt\Component\Repofuck\Traits\Operations;
 	
 	/**
 	 * Entity pointer

--- a/src/Prjkt/Component/Repofuck/Containers/Repositories.php
+++ b/src/Prjkt/Component/Repofuck/Containers/Repositories.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Prjkt\Component\Repofuck\Containers\Repositories;
+namespace Prjkt\Component\Repofuck\Containers;
 
 
 use Prjkt\Component\Repofuck\{
@@ -10,7 +10,7 @@ use Prjkt\Component\Repofuck\{
 
 class Repositories
 {
-	use Operations;
+	use \Prjkt\Component\Repofuck\Traits\Operations;
 
 	/**
 	 * Repository pointer

--- a/src/Prjkt/Component/Repofuck/Repofuck.php
+++ b/src/Prjkt/Component/Repofuck/Repofuck.php
@@ -23,11 +23,9 @@ use Exceptions\{
 	InvalidCallbackReturn
 };
 
-use Traits\Operations;
-
 abstract class Repofuck
 {
-	use Operations;
+	use Traits\Operations;
 
 	/**
 	 * Laravel's App instance

--- a/src/Prjkt/Component/Repofuck/Repofuck.php
+++ b/src/Prjkt/Component/Repofuck/Repofuck.php
@@ -384,7 +384,7 @@ abstract class Repofuck
 	 */
 	protected function map(array $inserts, array $keys = [], Model $entity = null) : Model
 	{
-		$entity = ! is_null($entity) ? $this->entities->current() : $entity;
+		$entity = ! is_null($entity) ? $entity : $this->entities->current();
 
 		if ( $this->hasValues($keys) ) {
 

--- a/src/Prjkt/Component/Repofuck/Repofuck.php
+++ b/src/Prjkt/Component/Repofuck/Repofuck.php
@@ -11,11 +11,6 @@ use Illuminate\Database\Eloquent\{
 	Builder
 };
 
-use Containers\{
-	Entities,
-	Repositories
-};
-
 use Exceptions\{
 	EntityNotDefined,
 	ResourceNotFound,
@@ -39,14 +34,14 @@ abstract class Repofuck
 	 *
 	 * @var \Prjkt\Component\Repofuck\Containers\Entities
 	 */
-	protected $entities;
+	public $entities;
 
 	/**
 	 * Repositories container
 	 *
 	 * @var \Prjkt\Component\Repofuck\Containers\Repositories
 	 */
-	protected $repositories;
+	public $repositories;
 
 	/**
 	 * Resources
@@ -96,15 +91,15 @@ abstract class Repofuck
 	 */
 	public function loadContainers()
 	{
-		$this->entities = new Entities;
-		$this->repositories = new Repositories;
+		$this->entities = new \Prjkt\Component\Repofuck\Containers\Entities;
+		$this->repositories = new \Prjkt\Component\Repofuck\Containers\Repositories;
 	}
 
 	/**
 	 * Loads all resources for the repository to use
 	 *
 	 */
-	protected function loadResources() : bool
+	protected function loadResources()
 	{
 		if ( $this->hasValues($this->resources) ) {
 			array_walk($this->resources, [$this, 'register']);
@@ -142,8 +137,8 @@ abstract class Repofuck
 		}
 
 		// If the entity property has not yet defined, set it with first configured entity
-		if ( ! is_object($this->entities->has() ) ) {
-			$this->entities->set($this->entities->resolve());
+		if ( ! is_object($this->entities->has()) ) {
+			$this->entities->set($this->entities->resolve(null, $this->resolveRepoName($this)));
 		}
 
 		return true;
@@ -290,7 +285,7 @@ abstract class Repofuck
 	{
 		$parameters = ! $this->hasValues($parameters) ? $this->getData() : $parameters;
 
-		$return = call_user_func_array($function, [$parameters, $this]);
+		$return = call_user_func_array($function, [$this, $parameters]);
 
 		switch($return)
 		{
@@ -318,7 +313,7 @@ abstract class Repofuck
 		}
 
 		// If there's a repository being persisted, return it, defer to self when there's none
-		return $this->isRepofuck($this->repositories->current()) ?
+		return $this->isRepofuck($this->repositories->has()) ?
 			$this->repositories->resolve() : $this;
 	}
 

--- a/src/Prjkt/Component/Repofuck/Traits/Operations.php
+++ b/src/Prjkt/Component/Repofuck/Traits/Operations.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Prjkt\Component\Repofuck\Repofuck\Traits;
+namespace Prjkt\Component\Repofuck\Traits;
 
 trait Operations
 {


### PR DESCRIPTION
On L387, branch: v1.0.0-alpha-rc1 (L391 on master) 

`$entity = ! is_null($entity) ? $this->entities->current() : $entity;`

As I read it: "If the `$entity` is not null, then assign the current entity to it, else, leave it be."
