### PR TITLE
Correcting the premature end of a loop

### DIFF
--- a/src/Prjkt/Component/Repofuck/Repofuck.php
+++ b/src/Prjkt/Component/Repofuck/Repofuck.php
@@ -484,7 +484,7 @@ abstract class Repofuck
 			foreach($inserts as $key => $val)
 			{
 				if ( ! in_array($key, $keys) ) {
-					break;
+					continue;
 				}
 
 				$entity->{$key} = $val;


### PR DESCRIPTION
L482-494
```
               if ( $this->hasValues($this->keys) ) {
			foreach($inserts as $key => $val)
			{
				if ( ! in_array($key, $keys) ) {
					break;
				}
				$entity->{$key} = $val;
			}
			return $entity;
		}
```

If I were to interpret L486-488 it is "If an item is not in the `$keys`, stop the loop. 

Suppose that `$this->keys` has `['username', 'password']` and the `$inserts` has `['username' => 'cmoran', 'id' => '2', 'password' => 'come$h0t', 'sex' => 'F']`. I presume that the aforementioned code is supposed to filter. However the word `break` seems to cut the loop prematurely. Running the code above, the `$entity` shall bear an object with only `['username'=> 'cmoran']` value in the `$attributes`, instead of the supposed `['username'=> 'cmoran', 'password' => 'come$h0t']`.

To  see how it goes, I shall illustrate. (`In` means Iteration no. n):

I1: `$keys = ['username', 'password']` has `username`? True, so `$entity->{'username'} = 'cmoran'`
I2: `$keys = ['username', 'password']` has `id`? False, so `break` the loop immediately
`return $entity`

Whence it should be:
I1: `$keys = ['username', 'password']` has `username`? True, so `$entity->{'username'} = 'cmoran'`.
I2: `$keys = ['username', 'password']` has `id`? False, so do nothing and `continue`.
I3: `$keys = ['username', 'password']` has `password`? True, so `$entity->{'password'} = 'come$h0t'`.
I4: `$keys = ['username', 'password']` has `sex`? False, so do nothing and `continue`.
`return $entity`

