### PR TITLE
Fixed inconsistencies: find() functions must use $columns as arguments

### DIFF
--- a/src/Prjkt/Component/Repofuck/Repofuck.php
+++ b/src/Prjkt/Component/Repofuck/Repofuck.php
@@ -303,7 +303,7 @@ abstract class Repofuck
 	 */
 	public function find($id) : Model
 	{
-		return $this->entity->find($id);
+		return $this->entity->find($id, $this->columns);
 	}
 
 	/**
@@ -320,7 +320,7 @@ abstract class Repofuck
 		{
 			case ( is_numeric($params) ):
 
-				$entity = $this->entity->findOrFail($params);
+				$entity = $this->entity->findOrFail($params, $this->columns);
 
 			break;
 


### PR DESCRIPTION
I have noticed, as I have used "Ctrl+F", that "columns" can only be found on `setColumns()` method,  `$columns` property, and Line 331 of `first()` method.

Thinking twice if I have to put it in `get()` method since `select()` function of the Query `Builder` suffice.
